### PR TITLE
テストコードの追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 requests==2.31.0
 python-dotenv==1.0.0
+pytest==7.4.4
+pytest-cov==4.1.0
+requests-mock==1.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[tool:pytest]
+python_files = test_*.py
+addopts = -v --cov=. --cov-report=term-missing
+
+[coverage:run]
+source = .
+omit = 
+    tests/*
+    setup.py

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,82 @@
+import pytest
+from unittest.mock import patch, Mock
+from weather import WeatherAPI
+
+@pytest.fixture
+def weather_api():
+    with patch.dict('os.environ', {'OPENWEATHERMAP_API_KEY': 'dummy_key'}):
+        return WeatherAPI()
+
+@pytest.fixture
+def mock_weather_response():
+    return {
+        'name': 'Tokyo',
+        'weather': [{'description': '晴れ'}],
+        'main': {
+            'temp': 20.5,
+            'humidity': 65,
+            'pressure': 1013
+        },
+        'wind': {
+            'speed': 3.2
+        }
+    }
+
+def test_weather_api_initialization(weather_api):
+    assert weather_api.api_key == 'dummy_key'
+    assert weather_api.base_url == 'http://api.openweathermap.org/data/2.5/weather'
+
+def test_format_weather_data(weather_api, mock_weather_response):
+    formatted_data = weather_api._format_weather_data(mock_weather_response)
+    
+    assert formatted_data['都市'] == 'Tokyo'
+    assert formatted_data['天気'] == '晴れ'
+    assert formatted_data['気温'] == '20.5°C'
+    assert formatted_data['湿度'] == '65%'
+    assert formatted_data['気圧'] == '1013hPa'
+    assert formatted_data['風速'] == '3.2m/s'
+
+@patch('requests.get')
+def test_get_weather_success(mock_get, weather_api, mock_weather_response):
+    mock_response = Mock()
+    mock_response.json.return_value = mock_weather_response
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    result = weather_api.get_weather('Tokyo')
+    
+    assert isinstance(result, dict)
+    assert result['都市'] == 'Tokyo'
+    assert '天気' in result
+    assert '気温' in result
+    assert '湿度' in result
+    assert '気圧' in result
+    assert '風速' in result
+
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert kwargs['params']['q'] == 'Tokyo'
+    assert kwargs['params']['appid'] == 'dummy_key'
+    assert kwargs['params']['units'] == 'metric'
+    assert kwargs['params']['lang'] == 'ja'
+
+@patch('requests.get')
+def test_get_weather_error(mock_get, weather_api):
+    mock_get.side_effect = requests.exceptions.RequestException('API error')
+    
+    result = weather_api.get_weather('InvalidCity')
+    
+    assert isinstance(result, str)
+    assert 'エラーが発生しました' in result
+
+def test_default_city(weather_api):
+    with patch('requests.get') as mock_get:
+        mock_response = Mock()
+        mock_response.json.return_value = mock_weather_response()
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = weather_api.get_weather()
+        
+        args, kwargs = mock_get.call_args
+        assert kwargs['params']['q'] == 'Tokyo'  # デフォルト値のテスト


### PR DESCRIPTION
本PRでは、weather.pyに対するテストコードを追加しました。

## 追加した内容

### テストファイル
- `tests/test_weather.py`: WeatherAPIクラスのテストコード
- `tests/__init__.py`: Pythonパッケージとして認識させるための空ファイル
- `setup.cfg`: pytestの設定ファイル

### テストケース
1. APIクラスの初期化テスト
2. 天気データのフォーマット処理テスト
3. 天気情報取得の成功ケーステスト
4. エラーハンドリングテスト
5. デフォルト都市設定テスト

### 依存関係の更新
- requirements.txtに以下のパッケージを追加:
  - pytest
  - pytest-cov（カバレッジレポート用）
  - requests-mock（HTTPリクエストのモック用）

## テストの実行方法
```bash
pytest
```

## テスト内容の説明
- モックを使用してHTTPリクエストをシミュレート
- 環境変数の制御
- エラーケースの検証
- データフォーマットの検証
- パラメータのバリデーション

## カバレッジ
- pytest-covを使用してカバレッジレポートを生成
- 主要なコードパスをカバー